### PR TITLE
Improve word normalization to reduce scoring misses and bleed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "httpx>=0.28.1",
     "pydantic>=2.12.5",
     "sentry-sdk>=2.20.0",
+    "simplemma>=1.2.0",
 ]
 
 [build-system]

--- a/shopr/main.py
+++ b/shopr/main.py
@@ -9,6 +9,8 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
+import simplemma
+
 from .elo import EloRank
 from .trello import (
     Checklist,
@@ -40,6 +42,9 @@ UNIT_RE = re.compile(
     r"|pkg|packs?|ct|count|x"
     r")\b"
 )
+
+# Item names are mostly Norwegian (Bokmål) with occasional English.
+LEMMA_LANGS = ("nb", "en")
 
 # Descriptors and packaging words that don't identify the item itself.
 # Leaving these in candidates causes both misses (the same item recorded
@@ -149,30 +154,18 @@ async def reset_label(
 
 
 def singularize(word: str) -> str:
-    """Strip a common English plural suffix from a word.
+    """Lemmatize a word so inflected forms resolve to the same candidate.
 
-    Best-effort heuristic, not a full stemmer: it exists to make
-    "tomato"/"tomatoes" or "egg"/"eggs" resolve to the same candidate
-    instead of being treated as unrelated items.
+    e.g. "gulrøtter"/"gulrot" (Norwegian, irregular plural) or
+    "tomatoes"/"tomato" (English) should produce the same identifier.
 
     Args:
-        word: Word to singularize
+        word: Word to lemmatize
 
     Returns:
-        Singularized word
+        Lemmatized word
     """
-    if len(word) <= 3:
-        return word
-    if word.endswith("ies"):
-        return word[:-3] + "y"
-    if word.endswith(("ses", "xes", "zes", "ches", "shes", "oes")):
-        return word[:-2]
-    # Words ending in "us"/"ss" (asparagus, hummus, swiss) aren't plurals.
-    if word.endswith(("us", "ss")):
-        return word
-    if word.endswith("s"):
-        return word[:-1]
-    return word
+    return simplemma.lemmatize(word, lang=LEMMA_LANGS)
 
 
 def lookup_candidates(name: str) -> list[str]:

--- a/shopr/main.py
+++ b/shopr/main.py
@@ -30,6 +30,31 @@ DEFAULT_SCORE = 1000.0
 UNSORTED_TAG = " [unsorted]"
 UNSORTED_RE = re.compile(r"\[unsorted\]")
 
+# Units of measure that trail a quantity (e.g. "2L", "500 g"). Stripped
+# together with the number so a stray unit letter doesn't survive as its
+# own candidate word and bleed into unrelated items.
+UNIT_RE = re.compile(
+    r"\d+(?:\.\d+)?\s*("
+    r"kg|kilograms?|g|grams?|lbs?|pounds?|oz|ounces?"
+    r"|ml|milliliters?|millilitres?|l|liters?|litres?"
+    r"|pkg|packs?|ct|count|x"
+    r")\b"
+)
+
+# Descriptors and packaging words that don't identify the item itself.
+# Leaving these in candidates causes both misses (the same item recorded
+# with/without a descriptor produces different full keys) and bleed
+# (unrelated items sharing a descriptor overwrite each other's fallback
+# word score, e.g. "fresh basil" and "fresh cilantro" both producing "fresh").
+STOPWORDS = {
+    "fresh", "frozen", "organic", "large", "small", "medium", "extra",
+    "chopped", "diced", "sliced", "minced", "ground", "raw", "ripe",
+    "fine", "coarse", "can", "cans", "bag", "bags", "box", "boxes",
+    "jar", "jars", "bunch", "bunches", "pack", "packs", "package",
+    "packages", "container", "containers", "bottle", "bottles",
+    "of", "and", "the", "a", "an", "for", "with",
+}
+
 
 # Type alias for scores
 Scores = defaultdict[str, float]
@@ -123,6 +148,33 @@ async def reset_label(
                 await client.remove_label(card.id, label["id"])
 
 
+def singularize(word: str) -> str:
+    """Strip a common English plural suffix from a word.
+
+    Best-effort heuristic, not a full stemmer: it exists to make
+    "tomato"/"tomatoes" or "egg"/"eggs" resolve to the same candidate
+    instead of being treated as unrelated items.
+
+    Args:
+        word: Word to singularize
+
+    Returns:
+        Singularized word
+    """
+    if len(word) <= 3:
+        return word
+    if word.endswith("ies"):
+        return word[:-3] + "y"
+    if word.endswith(("ses", "xes", "zes", "ches", "shes", "oes")):
+        return word[:-2]
+    # Words ending in "us"/"ss" (asparagus, hummus, swiss) aren't plurals.
+    if word.endswith(("us", "ss")):
+        return word
+    if word.endswith("s"):
+        return word[:-1]
+    return word
+
+
 def lookup_candidates(name: str) -> list[str]:
     """Strip useless characters and return candidate identifiers.
 
@@ -132,17 +184,20 @@ def lookup_candidates(name: str) -> list[str]:
     Returns:
         List of candidate identifiers
     """
-    # Remove unsorted tag, numbers, parentheses
-    stripped = (
-        name.lower()
-        .replace("[unsorted]", "")
-    )
-    # Remove digits and parentheses
-    stripped = re.sub(r"[\d\(\)]", "", stripped)
+    # Remove unsorted tag
+    stripped = name.lower().replace("[unsorted]", "")
+    # Remove quantity + unit combos (e.g. "2l", "500 g") so a stray unit
+    # letter doesn't survive as its own candidate
+    stripped = UNIT_RE.sub(" ", stripped)
+    # Treat remaining punctuation as word separators
+    stripped = re.sub(r"[\d\(\),.\-/&:;%]", " ", stripped)
     # Normalize whitespace
     stripped = re.sub(r"\s+", " ", stripped).strip()
 
-    candidates = sorted(stripped.split(" "))
+    words = [word for word in stripped.split(" ") if word]
+    words = [singularize(word) for word in words if word not in STOPWORDS]
+
+    candidates = sorted(words)
     logger.debug(f"Lookup {name} => {candidates}")
     return candidates
 
@@ -158,19 +213,42 @@ def lookup(scores: Scores, name: str) -> float:
         Score for the item
     """
     candidates = lookup_candidates(name)
-
-    # Use longest word as preferred identifier if we don't find an exact match
-    full_key = ",".join(candidates)
-    all_candidates = [full_key] + candidates
-
-    # Filter candidates that have scores
-    scored_candidates = [c for c in all_candidates if c in scores]
-
-    if not scored_candidates:
+    if not candidates:
         return DEFAULT_SCORE
 
-    # Find longest candidate
-    candidate = max(scored_candidates, key=len, default="")
+    full_key = ",".join(candidates)
+    if full_key in scores:
+        return scores[full_key]
+
+    # No exact match. Look for the known item whose words overlap the most
+    # (by Jaccard similarity) rather than just any single shared word - a
+    # single shared word (e.g. "chicken" in both "chicken broth" and
+    # "chicken thighs") is a weak, bleed-prone signal on its own.
+    query_words = set(candidates)
+    best_key = None
+    best_similarity = 0.0
+    for key in scores:
+        if "," not in key:
+            continue
+        key_words = set(key.split(","))
+        overlap = query_words & key_words
+        if not overlap:
+            continue
+        similarity = len(overlap) / len(query_words | key_words)
+        if similarity > best_similarity:
+            best_similarity = similarity
+            best_key = key
+
+    if best_key is not None:
+        logger.debug(f"Lookup {name} => best overlap candidate {best_key}")
+        return scores[best_key]
+
+    # Last resort: fall back to the longest single word with a score.
+    scored_words = [c for c in candidates if c in scores]
+    if not scored_words:
+        return DEFAULT_SCORE
+
+    candidate = max(scored_words, key=len)
     logger.debug(f"Lookup {name} => final candidate {candidate}")
     return scores[candidate]
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -106,12 +106,35 @@ class TestLookupCandidates:
         assert lookup_candidates("Milk [unsorted]") == ["milk"]
 
     def test_strips_numbers_and_parens(self) -> None:
-        """Test that numbers and parentheses are removed."""
-        assert lookup_candidates("Milk (2L)") == ["l", "milk"]
+        """Test that numbers, units, and parentheses are removed."""
+        assert lookup_candidates("Milk (2L)") == ["milk"]
 
     def test_normalizes_whitespace(self) -> None:
         """Test that extra whitespace is normalized."""
         assert lookup_candidates("  Whole   Milk  ") == ["milk", "whole"]
+
+    def test_strips_unit_with_no_space(self) -> None:
+        """Test that a unit glued to a number doesn't survive as a word."""
+        assert lookup_candidates("Yogurt (500g)") == ["yogurt"]
+
+    def test_strips_descriptor_stopwords(self) -> None:
+        """Test that non-identifying descriptors are filtered out."""
+        assert lookup_candidates("Fresh Basil") == ["basil"]
+        assert lookup_candidates("Fresh Cilantro") == ["cilantro"]
+
+    def test_singularizes_plurals(self) -> None:
+        """Test that plural and singular forms normalize to the same word."""
+        assert lookup_candidates("Tomatoes") == lookup_candidates("Tomato")
+        assert lookup_candidates("Eggs") == ["egg"]
+
+    def test_does_not_mangle_us_and_ss_endings(self) -> None:
+        """Test that words like "asparagus" and "swiss" aren't truncated."""
+        assert lookup_candidates("Asparagus") == ["asparagus"]
+        assert lookup_candidates("Swiss Cheese") == ["cheese", "swiss"]
+
+    def test_strips_extra_punctuation(self) -> None:
+        """Test that hyphens and commas are treated as separators."""
+        assert lookup_candidates("Low-Fat Milk") == ["fat", "low", "milk"]
 
 
 class TestLookup:
@@ -137,6 +160,29 @@ class TestLookup:
         scores = make_scores({"milk,whole": 500.0, "milk": 600.0})
         # Full key "milk,whole" should be preferred (it's longer)
         assert lookup(scores, "Whole Milk") == 500.0
+
+    def test_does_not_bleed_from_shared_word_when_better_overlap_exists(
+        self,
+    ) -> None:
+        """Test that a closer multi-word match wins over a single shared word."""
+        scores = make_scores(
+            {
+                "broth,chicken": 100.0,
+                "chicken,thigh": 700.0,
+                "chicken": 700.0,  # last trainer overwrote the shared word
+            }
+        )
+        # "Chicken Thighs" has no exact full-key match ("thighs" -> "thigh"
+        # singularizes differently here), but overlaps "chicken,thigh"
+        # fully and "broth,chicken" only partially - it should prefer the
+        # closer match instead of just falling back to the bare "chicken"
+        # word score.
+        assert lookup(scores, "Chicken Thigh Fillets") == 700.0
+
+    def test_falls_back_to_single_word_when_no_full_key_overlaps(self) -> None:
+        """Test the single-word fallback still works when nothing else matches."""
+        scores = make_scores({"chicken": 300.0})
+        assert lookup(scores, "Chicken Stock") == 300.0
 
 
 class TestUpdate:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -125,6 +125,12 @@ class TestLookupCandidates:
     def test_singularizes_plurals(self) -> None:
         """Test that plural and singular forms normalize to the same word."""
         assert lookup_candidates("Tomatoes") == lookup_candidates("Tomato")
+
+    def test_singularizes_norwegian_irregular_plurals(self) -> None:
+        """Test Norwegian irregular plurals, which English suffix-stripping
+        gets wrong (e.g. "gulrøtter" does not just drop an "-er")."""
+        assert lookup_candidates("Gulrøtter") == lookup_candidates("Gulrot")
+        assert lookup_candidates("Poteter") == lookup_candidates("Potet")
         assert lookup_candidates("Eggs") == ["egg"]
 
     def test_does_not_mangle_us_and_ss_endings(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -328,6 +328,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "sentry-sdk" },
+    { name = "simplemma" },
 ]
 
 [package.dev-dependencies]
@@ -343,6 +344,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "sentry-sdk", specifier = ">=2.20.0" },
+    { name = "simplemma", specifier = ">=1.2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -351,6 +353,15 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-httpx", specifier = ">=0.36.0" },
+]
+
+[[package]]
+name = "simplemma"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/21/11ae67cc092d4109be9c80df42441bf0f438a20ff7d22e44658fa3cdb0d9/simplemma-1.2.0.tar.gz", hash = "sha256:f561a9f0f41400d52ed4a0674a3e0423df64c41f5390602d2f071d6b687c5e68", size = 67542207, upload-time = "2026-06-01T17:16:52.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/29/ec27f68195841041b583661f4094a4edfd83601a8db43ab2901b4c4ae229/simplemma-1.2.0-py3-none-any.whl", hash = "sha256:a02fcbbb9eecc9c0e56eaea0c482eb43bf8bec8e33f45024b321a483bf77d854", size = 67520844, upload-time = "2026-06-01T17:16:25.604Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Strip number+unit combos (e.g. "2L", "500g") as a unit, so a stray
  unit letter no longer survives as its own candidate word
- Treat hyphens, commas, periods, slashes, etc. as word separators
- Filter out non-identifying descriptors (fresh, diced, organic, of,
  the, ...) that previously polluted the shared word-level fallback
- Singularize plurals so "tomato"/"tomatoes" resolve to the same key
- Replace the "longest matching word" fallback with a Jaccard-overlap
  match against known full keys, so items sharing one common word
  (e.g. "chicken broth" vs "chicken thighs") no longer bleed into
  each other's score